### PR TITLE
wield_scale must be a vector not a number removed because is default

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -766,7 +766,6 @@ local function register_torch_bow(name, desc, material, image, torch_bow_range, 
     minetest.register_tool("torch_bomb:torch_crossbow_" .. name, {
         description = S("@1 Torch Crossbow", desc),
         inventory_image = image,
-        wield_scale = 1,
         stack_max = 1,
         groups = nil,
 		sound = {


### PR DESCRIPTION
fixes #8

@corarona

[#L769](https://github.com/minetest-mods/torch_bomb/blob/master/init.lua#L769) this should say wield_scale = {x=1, y=1, z=1} or just be removed since 1 is the default i suppose.

https://github.com/minetest/minetest/blob/master/doc/lua_api.md?plain=1#L8679
https://codeberg.org/mineclonia/mineclonia/issues/955
https://git.minetest.land/MineClone2/MineClone2/issues/3971